### PR TITLE
Update YAML linter workflow to target 'main' branch

### DIFF
--- a/.github/workflows/tools_yaml_linter.yml
+++ b/.github/workflows/tools_yaml_linter.yml
@@ -4,7 +4,7 @@ name: "Tools - Validate YAML Schema"
 "on":
   pull_request:
     branches:
-      - "master"
+      - "main"
     paths:
       - ".yamllint"
       - "**.yaml"


### PR DESCRIPTION
Updated the YAML linter workflow to target the 'main' branch instead of 'master' to align with current branch naming conventions.