### PR TITLE
Update YAML linter configuration for line length

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -10,3 +10,5 @@ yaml-files:
 rules:
   empty-lines:
     level: warning
+  line-length:
+    max: 208


### PR DESCRIPTION
Adjust the YAML linter configuration to set the maximum line length to 208 characters, improving code readability and consistency.