### PR TITLE
Update certificate handling and git push command

### DIFF
--- a/.github/workflows/remove-certificate.yml
+++ b/.github/workflows/remove-certificate.yml
@@ -203,7 +203,12 @@ jobs:
       - job1
       - job2
     # https://stackoverflow.com/questions/69354003/github-action-job-fire-when-previous-job-skipped
-    if: always() && needs.job1.outputs.ExpiredCertfound == 'false' || needs.job2.outputs.PR_NR == ''
+    if: >
+      always() &&
+      (
+        needs.job1.outputs.ExpiredCertfound == 'false' ||
+        needs.job2.outputs.PR_NR == ''
+      )
     # && needs.job2.result == 'skipped'
     # || needs.job2.outputs.PR_NR == ''
     runs-on: ubuntu-slim

--- a/.github/workflows/remove-certificate.yml
+++ b/.github/workflows/remove-certificate.yml
@@ -72,7 +72,7 @@ jobs:
               catch {
                 Write-Host "Skipping invalid cert: $strFile"
                 continue
-              }                
+              }
 
               # Create variables with given values
               [datetime] $dtCurrentTimestamp = Get-Date

--- a/.github/workflows/remove-certificate.yml
+++ b/.github/workflows/remove-certificate.yml
@@ -60,7 +60,7 @@ jobs:
 
           # Retrieving files in all directories that have the file types cer, der, and pem
           # The column named Fullname is passed to the loop.
-          Get-ChildItem -Include ('*.cer', '*.der', '*.pem') -Recurse | Select -ExpandProperty Fullname | ForEach-Object {
+          Get-ChildItem -Path . -Include ('*.cer', '*.der', '*.pem') -Recurse | Select -ExpandProperty Fullname | ForEach-Object {
 
               #  Declaration and initialization of variables for the loop
               [string] $strFile = $_

--- a/.github/workflows/remove-certificate.yml
+++ b/.github/workflows/remove-certificate.yml
@@ -107,7 +107,7 @@ jobs:
 
                   # Update remote refs along with associated objects
                   # https://git-scm.com/docs/git-push
-                  git push
+                  git push --set-upstream origin HEAD
 
                   # Wert der Variable von 'False' auf 'True' setzen
                   $bExpiredCertfound = $true

--- a/.github/workflows/remove-certificate.yml
+++ b/.github/workflows/remove-certificate.yml
@@ -66,7 +66,13 @@ jobs:
               [string] $strFile = $_
 
               #
-              $cert = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2([string] $strFile)
+              try {
+                $cert = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2([string] $strFile)
+              }
+              catch {
+                Write-Host "Skipping invalid cert: $strFile"
+                continue
+              }                
 
               # Create variables with given values
               [datetime] $dtCurrentTimestamp = Get-Date


### PR DESCRIPTION
Enhance the certificate removal workflow with error handling for invalid certificates. Improve clarity in job execution conditions and update the git push command to set the upstream for the branch.